### PR TITLE
Fix utf-8 rendering and check language

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,10 @@ import Counter from "../components/Counter.jsx";
 import TodoList from "../components/TodoList.jsx";
 ---
 
-<html lang="en">
+<html lang="es">
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Astro + React Demo</title>
     <meta name="description" content="Un pequeño proyecto de ejemplo para probar Cursor con Astro y React." />
   </head>


### PR DESCRIPTION
Fix UTF-8 character rendering and correct HTML language attribute to 'es'.

The page was missing the `<meta charset="utf-8">` declaration, causing incorrect rendering of Spanish characters. Additionally, the `lang` attribute was set to 'en' despite all content being in Spanish, which was corrected to 'es'. A viewport meta tag was also added for better responsiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-4db55a3b-b3d9-4524-8aab-64e028b6290c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4db55a3b-b3d9-4524-8aab-64e028b6290c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

